### PR TITLE
Fixes some typos in example code

### DIFF
--- a/docs/c-knobs/e-useRangeKnob.mdx
+++ b/docs/c-knobs/e-useRangeKnob.mdx
@@ -27,7 +27,7 @@ import { useRangeKnob } from "retoggle";
 {() => {
     const [range, setRance] = useRangeKnob("Range", {
         initialValue: 4,
-        mix: 40,
+        min: 40,
         max: 300
     });
 

--- a/docs/c-knobs/f-useRangesKnob.mdx
+++ b/docs/c-knobs/f-useRangesKnob.mdx
@@ -29,12 +29,12 @@ import { useRangesKnob } from "retoggle";
    const rangeValues = useRangesKnob("Ranges", {
     xAxis: {
       initialValue: 4,
-      mix: 40,
+      min: 40,
       max: 300
     },
     yAxis: {
       initialValue: 4,
-      mix: 40,
+      min: 40,
       max: 300
     }
   });


### PR DESCRIPTION
There were a couple of instances of `mix` instead of `min` in the examples.