### PR TITLE
Fix UMD library name

### DIFF
--- a/config/webpack.lib.config.js
+++ b/config/webpack.lib.config.js
@@ -9,7 +9,7 @@ module.exports = env => ({
     path: path.resolve(__dirname, "../lib"),
     filename: "index.js",
     sourceMapFilename: "[file].map",
-    library: "storyhooks",
+    library: "retoggle",
     libraryTarget: "umd"
   },
   resolve: {


### PR DESCRIPTION
Not sure if this has caused any issues for anyone using this as standard module, so it could be a breaking change.