### PR TITLE
✨ support for multiple inspectors via context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ jest.config.js
 react-hooks.d.ts
 .babelrc
 .travis.yml
+.tgz

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "standard.enable": false
+}

--- a/docs/a-inspector/c-multipleinspector.mdx
+++ b/docs/a-inspector/c-multipleinspector.mdx
@@ -1,0 +1,94 @@
+---
+name: Multiple Inspectors
+menu: Inspector
+route: /multiple-inspectors
+---
+
+import { Playground } from "docz";
+import { Inspector, InspectorProvider, useNumberKnob } from "../../src/lib";
+
+### Multiple Inspectors
+
+If you need multiple isolated inspectors, you can do that by creating an `InspectorProvider` somewhere in the tree where you want isolation to occur.
+
+- First import the `Inspector` and `InspectorProvider`
+
+```javascript
+import { Inspector, InspectorProvider } from "retoggle";
+```
+
+- Next setup your component like this. Or as you'll see in the final example it can be done as a function as a child of the provider.
+```javascript
+export const Example = ({name}) => {
+  const [value] = useNumberKnob(name);
+  return (
+    <React.Fragment>
+      <h4>{name} {value}</h4>
+      <Inspector usePortal={false} />
+    </React.Fragment>
+  );
+}
+```
+
+- Finally put them in individual `InspectorProvider`'s
+```javascript
+<React.Fragment>
+  <InspectorProvider>
+    <Example name="Example A" />
+  </InspectorProvider>
+  <InspectorProvider>
+    <Example name="Example B" />
+  </InspectorProvider>
+</React.Fragment>
+```
+
+<Playground>
+  {() => {
+    const Example = ({name}) => {
+      const [value] = useNumberKnob(name);
+      return (
+        <React.Fragment>
+          <h4>{name} {value}</h4>
+          <Inspector usePortal={false} />
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <React.Fragment>
+        <InspectorProvider>
+          <Example name="Example A" />
+        </InspectorProvider>
+        <InspectorProvider>
+          <Example name="Example B" />
+        </InspectorProvider>
+      </React.Fragment>
+    );
+  }}
+</Playground>
+
+#### Function as a child
+
+If for whatever reason you really don't want define a function component externally, it can technically be done in a function as a child.
+
+```javascript
+<InspectorProvider>
+  {() => {
+    const ExampleC = () => {
+      const [value] = useNumberKnob('Example C');
+      return (
+        <React.Fragment>
+          <h4>Example C {value}</h4>
+          <Inspector usePortal={false} />
+        </React.Fragment>
+      );
+    }
+    return <ExampleC />
+  }}
+</InspectorProvider>
+```
+
+> Note: There is a caveat to setting up your knobs like `ExampleC` (i.e. using a function as a child) which is that you must still 
+> define a function component that will invoke the hooks to add the knobs. Otherwise it does not work as expected as that would be
+> breaking one of the rules of hooks in that hooks cannot be invoked from a callback. And aside from from that, your function
+> component would basically get re-created everytime that function as a child is invoked. YMMV with this method.

--- a/docs/c-knobs/j-customKnob.mdx
+++ b/docs/c-knobs/j-customKnob.mdx
@@ -21,37 +21,39 @@ A custom knob comprises of two parts
 ## The API
 
 ```javascript
-import { setKnob, removeKnob, addKnobRenderer } from "retoggle";
+import { useInspector } from "retoggle";
 ```
 
-- `addKnobRenderer(type, Component)` - Registers a knob renderer component to the inspector panel.
+- `const inspector = useInspector()` - Gets the current inspector state from the context.
+
+- `inspector.addKnobRenderer(type, Component)` - Registers a knob renderer component to the inspector panel.
 
   - `type`: Knob type. This is a string. Should be unique across knobs.
   - `Component`: The component constructor.
 
 ```javascript
 import Component from './myComponent';
-addKnobRenderer("chart", Component);
+inspector.addKnobRenderer("chart", Component);
 ```
 
-- `setKnob(props)` - You would call this method to update your knob. The following are required props.
+- `inspector.setKnob(props)` - You would call this method to update your knob. The following are required props.
 
   - `name`: The name of your knob.
   - `type`: Type of the knob.
 
 ```javascript
-setKnob({
+inspector.setKnob({
   name: "Custom knob sample",
   type: "chart",
   data: {value: 5}
 });
 ```
 
-- `removeKnob(name)` - You would call this method remove your knob from the inspector. Usually when your hook unmounts.
+- `inspector.removeKnob(name)` - You would call this method remove your knob from the inspector. Usually when your hook unmounts.
   - `name`: The name of your knob.
 
 ```
-removeKnob("Custom knob sample")
+inspector.removeKnob("Custom knob sample")
 ```
 
 ## A sample implementation
@@ -102,15 +104,17 @@ export default function Chart({ data }) {
 
 ```javascript
 import { useState, useEffect } from "react";
-import { setKnob, removeKnob, addKnobRenderer } from "retoggle";
+import { useInspector } from "retoggle";
 import Component from "./component";
 
 const KnobType = "chart";
-// Registering the knob renderer
-addKnobRenderer(KnobType, Component);
 
 export default function useChartKnob(name: string, value: any) {
   const [data, setData] = useState([]);
+  const inspector = useInspector();
+
+  // Registering the knob renderer
+  inspector.addKnobRenderer(KnobType, Component);
 
   useEffect(
     () => {
@@ -118,7 +122,7 @@ export default function useChartKnob(name: string, value: any) {
       setData([...data, randomNumber]);
 
       // Passing the props to the renderer component
-      setKnob({
+      inspector.setKnob({
         name,
         type: KnobType,
         data
@@ -129,7 +133,7 @@ export default function useChartKnob(name: string, value: any) {
 
   useEffect(() => {
     // cleaning up before unmounting
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 }
 ```

--- a/src/example/custom-chart-knob/index.ts
+++ b/src/example/custom-chart-knob/index.ts
@@ -1,18 +1,18 @@
 import { useState, useEffect } from "react";
-import { setKnob, removeKnob, addKnobRenderer } from "../../lib";
+import { useInspector } from "../../lib";
 import Component from "./component";
-
-addKnobRenderer("chart", Component);
 
 export default function useChartKnob(name: string, value: any) {
   const [data, setData] = useState([] as number[]);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("chart", Component);
 
   useEffect(
     () => {
       const randomNumber = Math.floor(Math.random() * 6) + 1;
       setData([...data, randomNumber]);
 
-      setKnob({
+      inspector.setKnob({
         name,
         type: "chart",
         data
@@ -22,6 +22,6 @@ export default function useChartKnob(name: string, value: any) {
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,6 @@
 export { Inspector } from "./inspector";
+export { default as useInspector } from "./inspector/useInspector";
+export { default as InspectorProvider } from "./inspector/provider";
 export { default as useLog } from "./use-log";
 export { default as useBooleanKnob } from "./knobs/useBooleanKnob";
 export { default as useTextKnob } from "./knobs/useTextKnob";

--- a/src/lib/inspector/knobs/index.tsx
+++ b/src/lib/inspector/knobs/index.tsx
@@ -1,23 +1,19 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import styled from "styled-components";
-import {
-  haveKnobs,
-  addKnobSubscriber,
-  getKnobs,
-  getKnobRenderer
-} from "../state-handler";
+import { InspectorContext } from "../provider";
 
 const Container = styled.div``;
 
 export default function Knobs() {
   const [knobs, setKnobs] = useState({});
+  const inspector = useContext(InspectorContext);
 
   useEffect(() => {
-    if (haveKnobs()) {
-      setKnobs({ ...getKnobs() });
+    if (inspector.haveKnobs()) {
+      setKnobs({ ...inspector.getKnobs() });
     }
 
-    addKnobSubscriber((knob: any) => {
+    inspector.addKnobSubscriber((knob: any) => {
       setKnobs((previousKnobs: any) => ({
         ...previousKnobs,
         ...{ [knob.name]: knob }
@@ -32,7 +28,7 @@ export default function Knobs() {
   return (
     <Container>
       {Object.entries(knobs).map(([name, knob]: any) => {
-        const Component = getKnobRenderer(knob.type);
+        const Component = inspector.getKnobRenderer(knob.type);
         return <Component key={knob.name} {...knob} />;
       })}
     </Container>

--- a/src/lib/inspector/logs/index.tsx
+++ b/src/lib/inspector/logs/index.tsx
@@ -1,18 +1,19 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import styled from "styled-components";
-import { haveLogs, addLogSubscriber, getLogs } from "../state-handler";
+import { InspectorContext } from "../provider";
 import Log from "./log";
 
 const Container = styled.div``;
 
 export default function Logs() {
   const [logs, setLogs] = useState({});
+  const inspector = useContext(InspectorContext);
   useEffect(() => {
-    if (haveLogs()) {
-      setLogs({ ...getLogs() });
+    if (inspector.haveLogs()) {
+      setLogs({ ...inspector.getLogs() });
     }
 
-    addLogSubscriber((log: any) => {
+    inspector.addLogSubscriber((log: any) => {
       setLogs((previousLogs: any) => ({
         ...previousLogs,
         ...{ [log.name]: log }

--- a/src/lib/inspector/provider.tsx
+++ b/src/lib/inspector/provider.tsx
@@ -1,0 +1,17 @@
+import React, { useState, createContext } from 'react';
+import StateHandler, { defaultStateHandler } from './state-handler';
+
+export const InspectorContext = createContext<StateHandler>(defaultStateHandler);
+
+type Props = {
+    children?: any;
+}
+
+export default function InspectorProvider({ children }: Props) {
+    const [handler] = useState(new StateHandler());
+    return (
+        <InspectorContext.Provider value={handler}>
+            {typeof children === 'function' ? children() : children}
+        </InspectorContext.Provider>
+    )
+}

--- a/src/lib/inspector/state-handler.ts
+++ b/src/lib/inspector/state-handler.ts
@@ -1,4 +1,4 @@
-class StateHandler {
+export default class StateHandler {
   public logs: any;
   public knobs: any;
   public knobRenderers: any = {};
@@ -74,17 +74,29 @@ class StateHandler {
 }
 
 // singleton
-const stateHandler = new StateHandler();
+export const defaultStateHandler = new StateHandler();
 
-export const addLogSubscriber = stateHandler.addLogSubscriber;
-export const addKnobSubscriber = stateHandler.addKnobSubscriber;
-export const haveLogs = stateHandler.haveLogs;
-export const haveKnobs = stateHandler.haveKnobs;
-export const getLogs = stateHandler.getLogs;
-export const getKnobs = stateHandler.getKnobs;
-export const setLog = stateHandler.setLog;
-export const removeLog = stateHandler.removeLog;
-export const setKnob = stateHandler.setKnob;
-export const removeKnob = stateHandler.removeKnob;
-export const addKnobRenderer = stateHandler.addKnobRenderer;
-export const getKnobRenderer = stateHandler.getKnobRenderer;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const addLogSubscriber = defaultStateHandler.addLogSubscriber;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const addKnobSubscriber = defaultStateHandler.addKnobSubscriber;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const haveLogs = defaultStateHandler.haveLogs;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const haveKnobs = defaultStateHandler.haveKnobs;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const getLogs = defaultStateHandler.getLogs;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const getKnobs = defaultStateHandler.getKnobs;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const setLog = defaultStateHandler.setLog;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const removeLog = defaultStateHandler.removeLog;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const setKnob = defaultStateHandler.setKnob;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const removeKnob = defaultStateHandler.removeKnob;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const addKnobRenderer = defaultStateHandler.addKnobRenderer;
+/** @deprecated use inspector context. using these methods will only affect inspectors not used in an inspector context */
+export const getKnobRenderer = defaultStateHandler.getKnobRenderer;

--- a/src/lib/inspector/useInspector/index.ts
+++ b/src/lib/inspector/useInspector/index.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { InspectorContext } from "../provider";
+
+export default function useInspector() {
+  return useContext(InspectorContext);
+}

--- a/src/lib/knobs/useBooleanKnob/index.ts
+++ b/src/lib/knobs/useBooleanKnob/index.ts
@@ -1,18 +1,14 @@
 import { useState, useEffect } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import useInspector from "../../inspector/useInspector";
 import Component from "./boolean";
-
-addKnobRenderer("boolean", Component);
 
 export default function useBooleanKnob(name: string, initialValue = false) {
   const [value, setValue] = useState(initialValue);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("boolean", Component);
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "boolean",
         value,
@@ -25,7 +21,7 @@ export default function useBooleanKnob(name: string, initialValue = false) {
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
   return [value, setValue] as const;
 }

--- a/src/lib/knobs/useColor/index.tsx
+++ b/src/lib/knobs/useColor/index.tsx
@@ -1,18 +1,14 @@
 import { useState, useEffect } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import useInspector from "../../inspector/useInspector";
 import Component from "./color";
-
-addKnobRenderer("color", Component);
 
 export default function useColorKnob(name: string, initialValue: string) {
   const [value, setValue] = useState(initialValue);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("color", Component);
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "color",
         value,
@@ -25,7 +21,7 @@ export default function useColorKnob(name: string, initialValue: string) {
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
   return [value, setValue] as const;
 }

--- a/src/lib/knobs/useNumberKnob/index.ts
+++ b/src/lib/knobs/useNumberKnob/index.ts
@@ -1,18 +1,14 @@
 import { useState, useEffect } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import useInspector from "../../inspector/useInspector";
 import Component from "./number";
-
-addKnobRenderer("number", Component);
 
 export default function useTextKnob(name: string, initialValue = 0) {
   const [value, setValue] = useState(initialValue);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("number", Component);
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "number",
         value,
@@ -25,7 +21,7 @@ export default function useTextKnob(name: string, initialValue = 0) {
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 
   return [value, setValue] as const;

--- a/src/lib/knobs/useObject/index.ts
+++ b/src/lib/knobs/useObject/index.ts
@@ -1,18 +1,14 @@
 import { useState, useEffect } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import useInspector from "../../inspector/useInspector";
 import Component from "./object";
-
-addKnobRenderer("object", Component);
 
 export default function useObjectKnob(name: string, initialValue = {}) {
   const [value, setValue] = useState(initialValue);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("object", Component);
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "object",
         value,
@@ -25,7 +21,7 @@ export default function useObjectKnob(name: string, initialValue = {}) {
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 
   return [value, setValue] as const;

--- a/src/lib/knobs/useRangeKnob/index.ts
+++ b/src/lib/knobs/useRangeKnob/index.ts
@@ -1,21 +1,17 @@
 import { useState, useEffect } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import useInspector from "../../inspector/useInspector";
 import Component from "./range";
-
-addKnobRenderer("range", Component);
 
 export default function useRangeKnob(
   name: string,
   { initialValue = 0, min = 0, max = 100 }
 ) {
   const [value, setValue] = useState(initialValue);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("range", Component);
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "range",
         value,
@@ -28,7 +24,7 @@ export default function useRangeKnob(
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 
   return [value, setValue] as const;

--- a/src/lib/knobs/useRangesKnob/index.ts
+++ b/src/lib/knobs/useRangesKnob/index.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { removeKnob } from "../../inspector/state-handler";
+import { useEffect, useContext } from "react";
+import useInspector from "../../inspector/useInspector";
 import useRangeKnob from "../useRangeKnob";
 import { Props } from "../useRangeKnob/range";
 
@@ -7,6 +7,7 @@ export default function useRangesKnob(
   name: string,
   ranges: { [name: string]: Props }
 ) {
+  const inspector = useInspector();
   const results = {
     values: {}
   };
@@ -19,7 +20,7 @@ export default function useRangesKnob(
   useEffect(() => {
     return () => {
       Object.entries(ranges).forEach(([propertyName]) => {
-        removeKnob(`${name}-${propertyName}`);
+        inspector.removeKnob(`${name}-${propertyName}`);
       });
     };
   }, []);

--- a/src/lib/knobs/useSelectKnob/index.ts
+++ b/src/lib/knobs/useSelectKnob/index.ts
@@ -1,12 +1,6 @@
-import { useState, useEffect } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import { useState, useEffect, useContext } from "react";
+import useInspector from "../../inspector/useInspector";
 import Component from "./select";
-
-addKnobRenderer("select", Component);
 
 export default function useSelectKnob(
   name: string,
@@ -14,9 +8,11 @@ export default function useSelectKnob(
   initialValue: string
 ) {
   const [value, setValue] = useState(initialValue);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("select", Component);
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "select",
         options,
@@ -30,7 +26,7 @@ export default function useSelectKnob(
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 
   return [value, setValue] as const;

--- a/src/lib/knobs/useTextKnob/index.ts
+++ b/src/lib/knobs/useTextKnob/index.ts
@@ -1,18 +1,14 @@
-import { useState, useEffect } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import { useState, useEffect, useContext } from "react";
+import useInspector from "../../inspector/useInspector";
 import Component from "./text";
-
-addKnobRenderer("text", Component);
 
 export default function useTextKnob(name: string, initialValue = "") {
   const [value, setValue] = useState(initialValue);
+  const inspector = useInspector();
+  inspector.addKnobRenderer("text", Component);
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "text",
         value,
@@ -25,7 +21,7 @@ export default function useTextKnob(name: string, initialValue = "") {
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 
   return [value, setValue] as const;

--- a/src/lib/knobs/useTimeMachine/index.ts
+++ b/src/lib/knobs/useTimeMachine/index.ts
@@ -1,14 +1,8 @@
 // https://twitter.com/dan_abramov/status/1058870951373344769
 
-import { useEffect, useReducer } from "react";
-import {
-  setKnob,
-  removeKnob,
-  addKnobRenderer
-} from "../../inspector/state-handler";
+import { useEffect, useReducer, useContext } from "react";
+import useInspector from "../../inspector/useInspector";
 import Component from "./timeMachine";
-
-addKnobRenderer("timemachine", Component);
 
 export default function useTimeMachine(name: string, currentState: any) {
   const [machineState, dispatch] = useReducer(
@@ -33,6 +27,8 @@ export default function useTimeMachine(name: string, currentState: any) {
       version: -1
     }
   );
+  const inspector = useInspector();
+  inspector.addKnobRenderer("timemachine", Component);
 
   const { history, version } = machineState;
   if (currentState !== history[history.length - 1]) {
@@ -41,7 +37,7 @@ export default function useTimeMachine(name: string, currentState: any) {
 
   useEffect(
     () => {
-      setKnob({
+      inspector.setKnob({
         name,
         type: "timemachine",
         min: 0,
@@ -59,7 +55,7 @@ export default function useTimeMachine(name: string, currentState: any) {
   );
 
   useEffect(() => {
-    return () => removeKnob(name);
+    return () => inspector.removeKnob(name);
   }, []);
 
   return history[version];

--- a/src/lib/use-log/index.ts
+++ b/src/lib/use-log/index.ts
@@ -1,10 +1,11 @@
-import { useEffect } from "react";
-import { setLog, removeLog } from "../inspector/state-handler";
+import { useEffect, useContext } from "react";
+import useInspector from "../inspector/useInspector";
 
 export default function useLog(name: string, value: string | boolean | object) {
+  const inspector = useInspector();
   useEffect(
     () => {
-      setLog({
+      inspector.setLog({
         name,
         props: {
           name,
@@ -17,7 +18,7 @@ export default function useLog(name: string, value: string | boolean | object) {
 
   useEffect(() => {
     return () => {
-      removeLog(name);
+      inspector.removeLog(name);
     };
   }, []);
 }


### PR DESCRIPTION
its not the api proposed [here](https://github.com/Raathigesh/retoggle/issues/26#issuecomment-522309963), but it should give enough flexibility to accomplish what was being requested. i'm personally looking to use this in a project using react-styleguidist where I can swap out the `ReactExample` component they use and apply an inspector provider on it.

Note: i've been able to maintain backwards compatibility with the documented custom knob api with the caveat that it would only apply to the global inspector, not any of the ones inside an `InspectorProvider`. I've deprecated those api methods as the preferred method is to use the inspector context to register the knobs.