### PR TITLE
allow passing in custom state handler

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,6 @@
 export { Inspector } from "./inspector";
 export { default as useInspector } from "./inspector/useInspector";
-export { default as InspectorProvider } from "./inspector/provider";
+export { default as InspectorProvider, InspectorContext } from "./inspector/provider";
 export { default as useLog } from "./use-log";
 export { default as useBooleanKnob } from "./knobs/useBooleanKnob";
 export { default as useTextKnob } from "./knobs/useTextKnob";

--- a/src/lib/inspector/provider.tsx
+++ b/src/lib/inspector/provider.tsx
@@ -4,13 +4,14 @@ import StateHandler, { defaultStateHandler } from './state-handler';
 export const InspectorContext = createContext<StateHandler>(defaultStateHandler);
 
 type Props = {
-    children?: any;
+  children?: any;
+  value?: StateHandler;
 }
 
-export default function InspectorProvider({ children }: Props) {
+export default function InspectorProvider({ children, value }: Props) {
     const [handler] = useState(new StateHandler());
     return (
-        <InspectorContext.Provider value={handler}>
+        <InspectorContext.Provider value={value || handler}>
             {typeof children === 'function' ? children() : children}
         </InspectorContext.Provider>
     )


### PR DESCRIPTION
Looks like I need a little enhancement to my previous changes. As i'm trying to integrate this into a react-styleguidist project it turns out there are basically 2 react tree's it uses. There's an outer one that renders the pages, then an inner one that is created via a `ReactDOM.mount` to mount the code example block. So in my scenario I need to be able to pass the context value from the outer tree and pass it into the inner tree. So I need to have the ability to pass in a custom context value or have access to the `InspectorContext` created from `React.createContext`. I've made both possible here.